### PR TITLE
TASK-7 - Add the OpenAPI export and frontend type-generation workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ COMPOSE_FILE := infra/compose/docker-compose.yml
 
 .DEFAULT_GOAL := help
 
-.PHONY: help up down backend-dev web-dev test test-backend test-web test-e2e
+.PHONY: help up down backend-dev web-dev openapi-export openapi-types test test-backend test-web test-e2e
 
 define require_file
 	@if [ ! -f "$(1)" ]; then \
@@ -33,6 +33,16 @@ backend-dev: ## Run the backend locally with uv
 web-dev: ## Run the Angular app locally with npm
 	$(call require_file,$(WEB_DIR)/package.json,the frontend app,TASK-3)
 	cd $(WEB_DIR) && npm run start
+
+openapi-export: ## Export the committed OpenAPI spec from the backend app
+	$(call require_file,$(API_DIR)/pyproject.toml,the backend app,TASK-2)
+	mkdir -p docs/api
+	cd $(API_DIR) && uv run python -m palio.app.export_openapi ../../docs/api/openapi.yaml
+
+openapi-types: ## Generate frontend TS types from the committed OpenAPI spec
+	$(call require_file,$(WEB_DIR)/package.json,the frontend app,TASK-3)
+	$(call require_file,docs/api/openapi.yaml,the committed OpenAPI spec,TASK-7)
+	cd $(WEB_DIR) && npm run generate:api-types
 
 test: test-backend test-web test-e2e ## Run all repository test suites
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ What is already in the repo:
 - milestone plan
 - backend FastAPI scaffold with explicit module facades and a minimal app factory
 - Angular 21 SPA scaffold under `apps/web/`
+- a committed OpenAPI export artifact at `docs/api/openapi.yaml`
 
 What is not in the repo yet:
 - Docker Compose or local bootstrap files
@@ -85,9 +86,10 @@ palio/
 ├─ .github/
 │  └─ workflows/
 ├─ apps/
-│  ├─ backend/
+│  ├─ api/
 │  └─ web/
 ├─ docs/
+│  ├─ api/
 │  ├─ architecture/
 │  ├─ domain/
 │  ├─ ops/
@@ -156,11 +158,13 @@ make help
 ```bash
 make backend-dev
 make test-backend
+make openapi-export
 cd apps/api && uv run python -m palio.shared.module_boundaries
 
 cd apps/web
 npm install
 make web-dev
+make openapi-types
 ```
 
 The Angular SPA currently exposes three lazy route areas:
@@ -169,6 +173,11 @@ The Angular SPA currently exposes three lazy route areas:
 - `/maxi`
 
 `make backend-dev` starts the placeholder FastAPI app. `make test-backend` currently runs only the scaffold smoke tests, not the full backend harness planned for later tasks.
+
+Contract workflow baseline:
+- `make openapi-export` commits the FastAPI-owned OpenAPI artifact to `docs/api/openapi.yaml`
+- `make openapi-types` regenerates ignored frontend TS declarations from that committed spec
+- Angular services stay hand-written even when types are generated
 
 ### Still-reserved targets
 

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -5,6 +5,7 @@ These rules apply only to backend.
 - Do NOT add `from __future__ import annotations` unless strictly necessary.
 - Use **modern typing** syntax (PEP 695): define type parameters directly in functions or classes (`def func[T](...) -> T:`). Avoid legacy typing (`TypeVar`, `Generic`, `Optional`, `Dict`, etc.).
 - Prefer `Annotated`.
+- Prefer `typer` to `argparse`.
 - Whne you change the code, update the related docstring using Google style with typing.
 - Use `is` for comparing enum members (including `StrEnum`) when identity is expected; use `==` only when intentional value-level equivalence (e.g., accepting raw strings) is required.
 - Prefer `Sequence[T]` to `tuple[T, ...]`

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -12,7 +12,13 @@ Current TASK-2 scaffold:
 Current local commands from this directory:
 - `uv run fastapi dev src/palio/app/main.py`
 - `uv run pytest`
+- `uv run python -m palio.app.export_openapi ../../docs/api/openapi.yaml`
 - `uv run python -m palio.shared.module_boundaries`
+
+Contract workflow baseline from TASK-7:
+- FastAPI owns the committed OpenAPI artifact at `docs/api/openapi.yaml`
+- the export command runs from application code and does not require a running backend
+- frontend TypeScript types are generated from that committed spec and are not committed
 
 Still deferred to later tasks:
 - Alembic configuration and migrations

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "fastapi[standard]>=0.116.0,<1.0.0",
     "httpx>=0.28.0,<1.0.0",
     "pytest>=8.3.0,<9.0.0",
+    "pyyaml>=6.0,<7.0",
+    "typer>=0.24,<1.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/apps/api/src/palio/app/export_openapi.py
+++ b/apps/api/src/palio/app/export_openapi.py
@@ -1,0 +1,45 @@
+"""Export the FastAPI OpenAPI contract as a committed repository artifact."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+import yaml
+
+from palio.app.factory import create_app
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+DEFAULT_OUTPUT_PATH = REPOSITORY_ROOT / "docs" / "api" / "openapi.yaml"
+
+
+def export_openapi(output_path: Path = DEFAULT_OUTPUT_PATH) -> Path:
+    """Write the current FastAPI OpenAPI schema to the requested path."""
+
+    resolved_output_path = output_path.resolve()
+    resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    specification = create_app().openapi()
+    resolved_output_path.write_text(
+        yaml.safe_dump(specification, sort_keys=False),
+        encoding="utf-8",
+    )
+    return resolved_output_path
+
+
+def main(
+    output: Annotated[
+        Path,
+        typer.Argument(
+            help="Output path for the generated OpenAPI YAML file.",
+            dir_okay=False,
+            resolve_path=True,
+        ),
+    ] = DEFAULT_OUTPUT_PATH,
+) -> None:
+    """Run the OpenAPI export CLI."""
+
+    typer.echo(export_openapi(output))
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/apps/api/tests/test_openapi_export.py
+++ b/apps/api/tests/test_openapi_export.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import yaml
+
+from palio.app.export_openapi import export_openapi
+
+
+def test_export_openapi_writes_current_contract(tmp_path: Path) -> None:
+    output_path = export_openapi(tmp_path / "openapi.yaml")
+
+    specification = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+
+    assert output_path.exists()
+    assert specification["info"]["title"] == "PalioBoard API"
+    assert specification["paths"].keys() >= {
+        "/api/admin/health",
+        "/api/public/health",
+        "/healthz",
+        "/realtime/health",
+    }

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -422,6 +422,8 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "pytest" },
+    { name = "pyyaml" },
+    { name = "typer" },
 ]
 
 [package.metadata]
@@ -429,6 +431,8 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.116.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "pytest", specifier = ">=8.3.0,<9.0.0" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "typer", specifier = ">=0.24,<1.0" },
 ]
 
 [[package]]

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -3,3 +3,4 @@
 /node_modules/
 /coverage/
 /playwright-report/
+/src/app/shared/api/generated/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -11,8 +11,14 @@ TASK-3 establishes the initial Angular 21 scaffold for M0 with:
 Current command surface:
 - `npm run start` starts the Angular dev server on port `4200`
 - `npm run build` builds the scaffolded SPA
+- `npm run generate:api-types` regenerates TS declarations from `../../docs/api/openapi.yaml`
 - `npm run typecheck` runs TypeScript-only validation
 - `npm run check-boundaries` enforces the initial frontend import rules
+
+Contract workflow baseline from TASK-7:
+- generated API types live under `src/app/shared/api/generated/`
+- generated API types are derived from the committed backend spec and are not committed
+- Angular services under `src/app/shared/api/` remain hand-written
 
 Still reserved for later M0 tasks:
 - frontend unit/integration harness wiring in TASK-9

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -23,6 +23,7 @@
         "@angular/cli": "^21.0.0",
         "@angular/compiler-cli": "^21.0.0",
         "dependency-cruiser": "^16.8.0",
+        "openapi-typescript": "^7.13.0",
         "typescript": "~5.9.0"
       }
     },
@@ -2952,6 +2953,89 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.10",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.10.tgz",
+      "integrity": "sha512-XCBR/9WHJ0cpezuunHMZjuFMl4KqUo7eiFwzrQrvm7lTXt0EBd3No8UY+9OyzXpDfreGEMMtxmaLZ+ksVw378g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.4.tgz",
@@ -3846,6 +3930,16 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -3887,6 +3981,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -4125,6 +4226,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chardet": {
       "version": "2.1.1",
@@ -5342,6 +5450,19 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5553,12 +5674,35 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6466,6 +6610,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ora": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
@@ -6540,6 +6728,24 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -6715,6 +6921,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -7757,6 +7973,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -7862,6 +8091,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
@@ -8118,6 +8354,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "18.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "ng serve --host 0.0.0.0 --port 4200",
     "build": "ng build",
+    "generate:api-types": "openapi-typescript ../../docs/api/openapi.yaml -o src/app/shared/api/generated/openapi.d.ts",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "check-boundaries": "depcruise --config dependency-cruiser.cjs src/app",
     "lint": "npm run check-boundaries",
@@ -27,6 +28,7 @@
     "@angular/cli": "^21.0.0",
     "@angular/compiler-cli": "^21.0.0",
     "dependency-cruiser": "^16.8.0",
+    "openapi-typescript": "^7.13.0",
     "typescript": "~5.9.0"
   }
 }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,65 @@
+openapi: 3.1.0
+info:
+  title: PalioBoard API
+  version: 0.1.0
+paths:
+  /api/admin/health:
+    get:
+      tags:
+      - admin
+      summary: Admin Health
+      operationId: admin_health_api_admin_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Admin Health Api Admin Health Get
+  /api/public/health:
+    get:
+      tags:
+      - public
+      summary: Public Health
+      operationId: public_health_api_public_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Public Health Api Public Health Get
+  /realtime/health:
+    get:
+      tags:
+      - realtime
+      summary: Realtime Health
+      operationId: realtime_health_realtime_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Realtime Health Realtime Health Get
+  /healthz:
+    get:
+      tags:
+      - meta
+      summary: Healthcheck
+      operationId: healthcheck_healthz_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Healthcheck Healthz Get

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -7,7 +7,7 @@ TASK-2 adds the first runnable backend scaffold under `apps/api/`.
 TASK-3 adds the Angular SPA scaffold under `apps/web/`.
 
 At this stage:
-- `make help`, `make backend-dev`, `make test-backend`, and `make web-dev` are runnable
+- `make help`, `make backend-dev`, `make test-backend`, `make web-dev`, `make openapi-export`, and `make openapi-types` are runnable
 - `make test-web` and `make test-e2e` now reach explicit frontend placeholder scripts for TASK-9
 - `make up` and `make down` are still reserved entrypoints
 - `make test` still fails overall until the web and e2e harnesses land
@@ -15,11 +15,14 @@ At this stage:
 Backend commands currently available:
 - `make backend-dev` starts the placeholder FastAPI app from `apps/api/src/palio/app/main.py`
 - `make test-backend` runs the narrow backend smoke suite currently in the scaffold
+- `make openapi-export` exports `docs/api/openapi.yaml` directly from the FastAPI app without starting a server
 - `cd apps/api && uv run python -m palio.shared.module_boundaries` runs the facade-only import check locally
 
 Frontend commands currently available:
 - `cd apps/web && npm install` installs the Angular 21 scaffold dependencies
 - `make web-dev` starts the Angular SPA with lazy `/admin`, `/public`, and `/maxi` routes
+- `make openapi-types` regenerates ignored TS declarations from the committed `docs/api/openapi.yaml` artifact
+- `cd apps/web && npm run generate:api-types` runs the app-local type-generation command
 - `cd apps/web && npm run check-boundaries` runs the dependency-cruiser import-boundary check
 
 ## Stable top-level targets
@@ -30,6 +33,8 @@ Use these target names going forward:
 - `make down`
 - `make backend-dev`
 - `make web-dev`
+- `make openapi-export`
+- `make openapi-types`
 - `make test`
 - `make test-backend`
 - `make test-web`

--- a/docs/qna/architecture/deployment and operations.md
+++ b/docs/qna/architecture/deployment and operations.md
@@ -49,7 +49,7 @@
 **Decision:** Backend integration tests use a real local Postgres test database, not SQLite.
 
 ### 94. What repository strategy is used?
-**Decision:** The whole project uses a monorepo containing frontend, backend, shared generated API types, migrations, and deployment configuration.
+**Decision:** The whole project uses a monorepo containing frontend, backend, committed API contract artifacts, frontend-generated API types, migrations, and deployment configuration.
 
 
 ## 12. Backend stack, project structure, and developer tooling

--- a/docs/testing/test-strategy.md
+++ b/docs/testing/test-strategy.md
@@ -73,9 +73,11 @@ Do not use large snapshot suites as a substitute for behavior tests. The fronten
 CI should also enforce architectural boundaries and contract hygiene using the repo’s agreed tooling. Ruff, Pyright, pytest, frontend lint/test/build, OpenAPI export/type generation checks, and import-boundary checks are part of the quality baseline.
 
 Current backend baseline note: the scaffold introduced in TASK-2 ships a local import-boundary command at `cd apps/api && uv run python -m palio.shared.module_boundaries`. Later CI wiring should execute the same rule automatically.
+TASK-7 adds `make openapi-export`, backed by `cd apps/api && uv run python -m palio.app.export_openapi ../../docs/api/openapi.yaml`, as the local contract-export command.
 
 Current frontend baseline:
 - TASK-3 introduces `cd apps/web && npm run check-boundaries`, backed by dependency-cruiser, as the initial CI-friendly import-boundary rule for shell isolation and generic `shared/` code.
+- TASK-7 introduces `make openapi-types` and `cd apps/web && npm run generate:api-types` so the frontend can regenerate ignored TS declarations from the committed OpenAPI artifact without a running backend.
 - TASK-9 will add the broader frontend and Playwright behavioral harnesses that complement this static guardrail.
 
 ## Test pyramid / test-layer overview


### PR DESCRIPTION
## What changed
- added a backend-owned OpenAPI export CLI plus `make openapi-export` to write the committed `docs/api/openapi.yaml` artifact from `create_app().openapi()`
- added frontend type generation from the committed spec via `openapi-typescript`, exposed as `make openapi-types` and `npm run generate:api-types`
- documented that the OpenAPI spec is committed while generated frontend declarations remain ignored, and updated the local-dev/testing/Q&A docs to match

## Why
- ADR-0007 and the Q&A docs require FastAPI to own the committed OpenAPI artifact and require frontend types to regenerate from that committed file without needing a running backend

## Scope
- [ ] Frontend only
- [ ] Backend only
- [x] Full stack
- [ ] Docs only
- [ ] Infra / CI

## Palio impact
- [x] No business-rule impact
- [ ] Official result persistence / materialization
- [ ] Standings / leaderboard projection
- [ ] Game lifecycle / state transitions
- [ ] Tournament progression
- [ ] Live ranking entry / conflict handling / recovery
- [ ] Identity / authorization / capabilities
- [ ] Public / maxi-screen read model
- [ ] Schema / migration
- [x] OpenAPI / API contract
- [ ] Architecture / ADR / governance

## Risk level
- [x] Low
- [ ] Medium
- [ ] High

## Owned paths touched
- [x] General frontend
- [x] General backend
- [ ] Core domain owned path
- [ ] Security owned path
- [x] Architecture/API owned path
- [ ] Release/infra owned path

## Validation
- [ ] Lint
- [x] Type checks
- [x] Unit tests
- [ ] Integration tests
- [ ] E2E / critical flow test
- [x] Manual verification

## Critical-flow checklist
- [x] No effect on leaderboard correctness
- [x] No effect on official result truth
- [x] No effect on auditability
- [x] No effect on public visibility timing
- [x] No effect on deploy/runtime safety

## Docs and contracts
- [ ] No doc update needed
- [ ] Architecture doc updated
- [ ] ADR updated
- [x] OpenAPI updated
- [ ] ER / schema doc updated
- [x] Testing docs updated
- [ ] Domain/business-rule docs updated

## Reviewer guidance
Areas that deserve the closest review:
- whether the export/typegen command surface is the right stable API for later CI wiring
- whether the committed-spec vs ignored-generated-types rule is clear enough across the updated docs
- whether the backend CLI wrapper and dependency choices for YAML and Typer are appropriately minimal

## Rollback plan
- revert commit `76875cc` to remove the export/type-generation workflow, dependency additions, committed spec artifact, and doc updates

## Agent notes
- Constraints followed: worked only in the dedicated TASK-7 worktree and kept Angular services hand-written while generating types only
- Assumptions made: storing generated declarations under `apps/web/src/app/shared/api/generated/` best matches the current web scaffold without introducing a shared package
- Uncertainties: none material after verification; frontend dependency audit warnings remain outside this task's scope
- Files intentionally not touched: frontend generated declarations were not committed, runtime Angular API services were left hand-written, realtime contracts were not formalized beyond current ADR scope
- Follow-up work not included in this PR: CI enforcement for export/type-generation drift and any cleanup of frontend dependency audit findings
